### PR TITLE
Add private_images() method

### DIFF
--- a/dopy/manager.py
+++ b/dopy/manager.py
@@ -236,6 +236,10 @@ class DoManager(object):
         json = self.request('/images/', params)
         return json['images']
 
+    def private_images(self):
+        json = self.request('/images?private=true')
+        return json['images']
+
     def image_v2_action(self, image_id, image_type, params=None):
         if params is None:
             params = {}

--- a/dopy/manager.py
+++ b/dopy/manager.py
@@ -237,8 +237,13 @@ class DoManager(object):
         return json['images']
 
     def private_images(self):
-        json = self.request('/images?private=true')
-        return json['images']
+        if self.api_version == 2:
+            json = self.request('/images?private=true')
+            return json['images']
+        else: 
+            params = {'filter': 'my_images'}
+            json = self.request('/images/', params)
+            return json['images']
 
     def image_v2_action(self, image_id, image_type, params=None):
         if params is None:


### PR DESCRIPTION
The v2 API requires the query param 'private=true' to be appended to
the /images endpoint. Added a method to lookup only private images.